### PR TITLE
Adds fix for libraries folder

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -64,6 +64,7 @@ project_files:
   - settings.local.devmodeON.php
   - scripts
   - commands
+  - nginx
   # - some-directory/file1.txt
   # - some-directory/file2.txt
   # - extra_files_dir_created_by_this_template/
@@ -104,6 +105,7 @@ removal_actions:
   - rm commands/host/login
   - rm commands/web/behat
   - rm commands/web/robo
+  - rm nginx/libraries.conf
   - rm settings.local.devmodeON.php
   - rm settings.local.devmodeOFF.php
   - rm -rf scripts

--- a/nginx/libraries.conf
+++ b/nginx/libraries.conf
@@ -1,0 +1,3 @@
+
+# Allow the alias "/libraries" to work without breaking actual assets in the libraries directory.
+rewrite ^/libraries$ /index.php last;


### PR DESCRIPTION
Out-of-the-box ddev doesn't allow the user to visit a Drupal page with the URL of `libraries`.
This change means it can happen, but also keeps actual libraries being served by Drupal. 