### PR TITLE
Run auth ssh command only if not on a Nixsal box

### DIFF
--- a/config.hooks.yaml
+++ b/config.hooks.yaml
@@ -5,7 +5,7 @@ hooks:
     - exec-host: "cp .ddev/scripts/git-hooks/commit-msg .git/hooks/commit-msg"
     - exec-host: "chmod +x .git/hooks/commit-msg"
   post-start:
-    - exec-host: "ddev auth ssh"
+    - exec-host: "if [ ! $ANNERTECH_LOCAL_DEV ]; then ddev auth ssh; fi"
   post-import-db:
     - exec: "drush cr"
     - exec: "drush sql:sanitize -y"


### PR DESCRIPTION
Nixsal boxes do not have the auth agent container on them, so this command will always fail and present an error to the engineer.

To reduce the number of queries and improve the chance of spotting an actual error, this logic checks an environment variable before running the command.