### PR TITLE
Adds the basis for the protect command and nginx snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Highly opinionated set of configs and commands used by Annertech in our DDEV wor
 - - `cloudflare`: Shares the project with the outside world over a Cloudflare tunnel
 - - `devmode [on|off]`: Adds custom settings.local.php file and allows easy toggle between production and development mode
 - - `login`: Opens a browser and logs you in to Drupal (works on local environments only)
+- - `protect`: Enable or disable basic auth on a nixsal hosted dev project
 - - `robo`: Runs robo inside the web container
 - Uses DDEV Hooks to properly instatiate project for development (see `config.hooks.yaml`)
 - Adds git hook to enforce proper commit messages
@@ -57,6 +58,7 @@ git add .ddev/commands/host/cr -f
 git add .ddev/commands/host/devmode -f
 git add .ddev/commands/host/githooks -f
 git add .ddev/commands/host/login -f
+git add .ddev/commands/host/protect -f
 git add .ddev/commands/host/remote-db -f
 git add .ddev/commands/web/behat -f
 git add .ddev/commands/web/robo -f

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Highly opinionated set of configs and commands used by Annertech in our DDEV wor
 - - `cloudflare`: Shares the project with the outside world over a Cloudflare tunnel
 - - `devmode [on|off]`: Adds custom settings.local.php file and allows easy toggle between production and development mode
 - - `login`: Opens a browser and logs you in to Drupal (works on local environments only)
-- - `protect`: Enable or disable basic auth on a nixsal hosted dev project
+- - `protect [on|off|reset]`: Enable or disable basic auth on a nixsal hosted dev project
 - - `robo`: Runs robo inside the web container
 - Uses DDEV Hooks to properly instatiate project for development (see `config.hooks.yaml`)
 - Adds git hook to enforce proper commit messages

--- a/commands/host/protect
+++ b/commands/host/protect
@@ -4,58 +4,72 @@
 ## Usage: protect [off|on|reset]
 ## Example: "ddev protect on"
 
+# Helpers ====================================
+red='\033[0;31m'
+green='\033[0;32m'
+yellow='\033[1;33m'
+NC='\033[0m'
+
+echo-red () { echo -e "${red}$1${NC}"; }
+echo-green () { echo -e "${green}$1${NC}"; }
+echo-yellow () { echo -e "${yellow}$1${NC}"; }
+# End Helpers ====================================
+
 # Vars
-PROTECT_FILE=${DDEV_APPROOT}/.ddev/passwd
+PROTECT_CONFIG=${DDEV_APPROOT}/.ddev/nginx/protect.conf
+PROTECT_FILE=${DDEV_APPROOT}/.ddev/.passwd
 PROTECT_USER=$(whoami)
 
 if [ ! $ANNERTECH_LOCAL_DEV ]; then
-  echo "========================================="
-  echo "= No changes have been made because     ="
-  echo "= this command requires a nixOS server. ="
-  echo "========================================="
+  echo-yellow "========================================="
+  echo-yellow "= No changes have been made because     ="
+  echo-yellow "= this command requires a nixOS server. ="
+  echo-yellow "========================================="
   exit 0
 fi
-
-case $@ in
-  off)
-    check_protect_file
-    # Comment-out the protect.conf lines starting with 'auth'
-    sed -i '/auth/s/^/#/g' $PROTECT_FILE
-    echo "Restarting ddev..."
-    ddev restart
-    ;;
-  on)
-    check_protect_file
-    # Uncomment lines starting with 'auth'
-    sed -i '/auth/s/^#//g' $PROTECT_FILE
-    echo "Restarting ddev..."
-    ddev restart
-    ;;
-  reset)
-    check_protect_file
-    echo "Restarting ddev..."
-    ddev restart
-    ;;
-  *)
-    echo "Please enter an action when running this command: e.g. on, off or reset"
-esac
 
 function check_protect_file() {
   ## Check if there's a passwd file
   if [ ! -f $PROTECT_FILE ]; then
     ## No file. Let's create one
-    echo "In order to use this script we need a passwd file."
-    if read -t 10 -sp "Press enter to create one or wait 10 seconds to exit..." CREATE; then
+    echo "In order to use this script we need to generate a password file."
+    if read -t 10 -n 1 -sp "Press enter to create one or wait 10 seconds to exit...\n" CREATE; then
       nix-shell -p apacheHttpd --run "htpasswd -c $PROTECT_FILE $PROTECT_USER"
     else
-      echo ""
-      echo "==================="
-      echo "= No file created ="
-      echo "==================="
-      echo ""
+      echo-yellow "\n\n No file created"
       exit 0
     fi
-  else
-    nix-shell -p apacheHttpd --run "htpasswd $PROTECT_FILE $PROTECT_USER"
   fi
 }
+
+# Command logic
+case $@ in
+  off)
+    check_protect_file
+    # Comment-out the protect.conf lines starting with 'auth'
+    echo-yellow "Disabling basic auth protection"
+    sed -i '/auth/s/^/#/g' $PROTECT_CONFIG
+    echo-green "Restarting ddev..."
+    ddev restart
+    ;;
+  on)
+    check_protect_file
+    # Uncomment lines starting with 'auth'
+    echo-yellow "Enabling basic auth protection"
+    sed -i '/auth/s/^#//g' $PROTECT_CONFIG
+    echo-green "Restarting ddev..."
+    ddev restart
+    ;;
+  reset)
+    echo-yellow "Reseting basic auth password"
+    if [ -f $PROTECT_FILE ]; then
+      nix-shell -p apacheHttpd --run "htpasswd $PROTECT_FILE $PROTECT_USER"
+    else
+      check_protect_file
+    fi
+    echo-green "Restarting ddev..."
+    ddev restart
+    ;;
+  *)
+    echo "Please enter an action when running this command: e.g. on, off or reset"
+esac

--- a/commands/host/protect
+++ b/commands/host/protect
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#ddev-generated
+## Description: Enable or disable basic auth on a nixsal hosted dev project
+## Usage: protect [off|on|reset]
+## Example: "ddev protect on"
+
+# Vars
+PROTECT_FILE=${DDEV_APPROOT}/.ddev/passwd
+PROTECT_USER=$(whoami)
+
+if [ ! $ANNERTECH_LOCAL_DEV ]; then
+  echo "========================================="
+  echo "= No changes have been made because     ="
+  echo "= this command requires a nixOS server. ="
+  echo "========================================="
+  exit 0
+fi
+
+case $@ in
+  off)
+    check_protect_file
+    # Comment-out the protect.conf lines starting with 'auth'
+    sed -i '/auth/s/^/#/g' $PROTECT_FILE
+    echo "Restarting ddev..."
+    ddev restart
+    ;;
+  on)
+    check_protect_file
+    # Uncomment lines starting with 'auth'
+    sed -i '/auth/s/^#//g' $PROTECT_FILE
+    echo "Restarting ddev..."
+    ddev restart
+    ;;
+  reset)
+    check_protect_file
+    echo "Restarting ddev..."
+    ddev restart
+    ;;
+  *)
+    echo "Please enter an action when running this command: e.g. on, off or reset"
+esac
+
+function check_protect_file() {
+  ## Check if there's a passwd file
+  if [ ! -f $PROTECT_FILE ]; then
+    ## No file. Let's create one
+    echo "In order to use this script we need a passwd file."
+    if read -t 10 -sp "Press enter to create one or wait 10 seconds to exit..." CREATE; then
+      nix-shell -p apacheHttpd --run "htpasswd -c $PROTECT_FILE $PROTECT_USER"
+    else
+      echo ""
+      echo "==================="
+      echo "= No file created ="
+      echo "==================="
+      echo ""
+      exit 0
+    fi
+  else
+    nix-shell -p apacheHttpd --run "htpasswd $PROTECT_FILE $PROTECT_USER"
+  fi
+}

--- a/install.yaml
+++ b/install.yaml
@@ -64,6 +64,7 @@ project_files:
   - settings.local.perfmode.php
   - scripts
   - commands
+  - commands/host/protect
   - nginx
   # - some-directory/file1.txt
   # - some-directory/file2.txt

--- a/nginx/protect.conf
+++ b/nginx/protect.conf
@@ -1,5 +1,5 @@
 #ddev-generated
 
 # Sets basic auth for the site
-auth_basic "Authentication required";
-auth_basic_user_file /mnt/ddev_config/passwd;
+#auth_basic "Authentication required";
+#auth_basic_user_file /mnt/ddev_config/passwd;

--- a/nginx/protect.conf
+++ b/nginx/protect.conf
@@ -1,0 +1,5 @@
+#ddev-generated
+
+# Sets basic auth for the site
+auth_basic "Authentication required";
+auth_basic_user_file /mnt/ddev_config/passwd;

--- a/nginx/protect.conf
+++ b/nginx/protect.conf
@@ -2,4 +2,4 @@
 
 # Sets basic auth for the site
 #auth_basic "Authentication required";
-#auth_basic_user_file /mnt/ddev_config/passwd;
+#auth_basic_user_file /mnt/ddev_config/.passwd;


### PR DESCRIPTION
Adds a command to enable/disable/reset basic auth on a project.

Assumptions:

1. The user is running the command on a Nixsal server. Otherwise it exits with a message
2. The username will always be the same as the logged-in user.
3. Password will be provided during set-up or reset.
