### PR TITLE
11 be specific during installation

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -72,6 +72,8 @@ project_files:
   - commands/host/githooks
   - commands/host/login
   - commands/host/remote-db
+  - commands/web/behat
+  - commands/web/robo
   - nginx
   # - some-directory/file1.txt
   # - some-directory/file2.txt

--- a/install.yaml
+++ b/install.yaml
@@ -63,7 +63,15 @@ project_files:
   - settings.local.devmode.php
   - settings.local.perfmode.php
   - scripts
-  - commands
+  - commands/host/branch
+  - commands/host/cex
+  - commands/host/cim
+  - commands/host/cloudflare
+  - commands/host/cr
+  - commands/host/devmode
+  - commands/host/githooks
+  - commands/host/login
+  - commands/host/remote-db
   - nginx
   # - some-directory/file1.txt
   # - some-directory/file2.txt


### PR DESCRIPTION
To get around the problem of copying a whole folder. Just copy the specific files we are adding.