### PR TITLE
feat: uses fragment in ddev branch when fragment is set and path is '/'

### DIFF
--- a/commands/host/branch
+++ b/commands/host/branch
@@ -36,6 +36,7 @@
 
 import sys
 from urllib.parse import urlparse
+from operator import attrgetter
 import datetime
 import subprocess
 
@@ -44,8 +45,9 @@ def extract_id(input_value):
     if input_value.isdigit():
         return input_value  # If it's purely numeric, treat it as the ID directly
     else:
-        path = urlparse(input_value).path
-        return path.split('/')[-1] if path.split('/')[-1].isdigit() else None
+        fragment, path = attrgetter('fragment', 'path')(urlparse(input_value))
+        card_path = fragment if path == '/' and fragment else path
+        return card_path.split('/')[-1] if card_path.split('/')[-1].isdigit() else None
 
 # Get current year and month
 current_year = datetime.datetime.now().year


### PR DESCRIPTION
Teamwork considers both of the following to be valid card URLs. The first contains a path and no fragment, while the second contains a fragment and no path:

  - https://projects.YOURCOMPANY.com/app/tasks/17458364
  - https://projects.YOURCOMPANY.com/#/tasks/17458364

This change allows both to be used in the ddev branch command.

Closes #18