### PR TITLE
Re-order check for .env file

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -140,6 +140,11 @@ dependencies:
 # DDEV environment variables can be interpolated into these actions.
 # post_install_actions are executed in the context of the target project's .ddev directory.
 post_install_actions:
+  - |
+    if [ ! -f ${DDEV_APPROOT}/.ddev/.env ]; then
+      cp ${DDEV_APPROOT}/.ddev/scripts/sample.env ${DDEV_APPROOT}/.ddev/.env
+      echo "Please configure upstream provider in .ddev/.env file!"
+    fi
   - git add ${DDEV_APPROOT}/.ddev/config.annertech.yaml -f
   - git add ${DDEV_APPROOT}/.ddev/settings.local.*mode.php -f
   - git add ${DDEV_APPROOT}/.ddev/commands/host/branch -f
@@ -163,11 +168,6 @@ post_install_actions:
   - cp -r ${DDEV_APPROOT}/.ddev/scripts/.vscode ${DDEV_APPROOT}/
   - cp -r ${DDEV_APPROOT}/.ddev/scripts/git-hooks/commit-msg ${DDEV_APPROOT}/.git/hooks/commit-msg
   - chmod +x ${DDEV_APPROOT}/.git/hooks/commit-msg
-  - |
-    if [ ! -f ${DDEV_APPROOT}/.ddev/.env ]; then
-      cp ${DDEV_APPROOT}/.ddev/scripts/sample.env ${DDEV_APPROOT}/.ddev/.env
-      echo "Please configure upstream provider in .ddev/.env file!"
-    fi
 
 # Shell actions that can be done during removal of the add-on.
 # Files listed in project_files section will be automatically removed here if they contain #ddev-generated line.


### PR DESCRIPTION
Currently the install hook fails if there isn't a `.env` file present.
This moves the check/copy of the template file up so that it can complete.