### PR TITLE
Create noindex.conf

### DIFF
--- a/nginx/noindex.conf
+++ b/nginx/noindex.conf
@@ -1,0 +1,7 @@
+#ddev-generated
+
+# Stop sites being indexed
+location /robots.txt {
+    add_header Content-Type text/plain;
+    return 200 "User-agent: *\nDisallow: /\n";
+}


### PR DESCRIPTION
Adds an override for presenting the robots.txt file, especially important for nixos servers.