### PR TITLE
Custom tips

### DIFF
--- a/commands/host/annertech-tip-of-the-day
+++ b/commands/host/annertech-tip-of-the-day
@@ -4,11 +4,17 @@
 ## Usage: install-tips
 ## Example: "ddev install-tips"
 
-echo "Removing old tips\n"
-rm ~/.ddev/.state.yaml ~/.ddev/.remote-config
-echo "Installing tips of the day\n"
-cat <<EOL >> ~/.ddev/global_config.yaml
+GLOBAL_CONF=~/.ddev/global_config.yaml
 
+if grep -q 'CUSTOM_TIPS_START' $GLOBAL_CONF; then
+  echo "Custom tips already installed, aborting."
+else
+  echo "Removing old tips"
+  rm ~/.ddev/.state.yaml ~/.ddev/.remote-config
+  echo "Installing tips of the day"
+cat <<EOL >> $GLOBAL_CONF
+
+##ANNERTECH_CUSTOM_TIPS_START
 # Annertech tips of the day
 messages:
   ticker_interval: 1
@@ -20,4 +26,6 @@ remote_config:
     ref: annertech-tips
     filepath: remote-config.jsonc
 # End of Annertech tips of the day
+##ANNERTECH_CUSTOM_TIPS_END
 EOL
+fi

--- a/commands/host/annertech-tip-of-the-day
+++ b/commands/host/annertech-tip-of-the-day
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#ddev-generated
+## Description: Install custom annertech tip of the day set in DDEV
+## Usage: install-tips
+## Example: "ddev install-tips"
+
+echo "Removing old tips\n"
+rm ~/.ddev/.state.yaml ~/.ddev/.remote-config
+echo "Installing tips of the day\n"
+cat <<EOL >> ~/.ddev/global_config.yaml
+
+# Annertech tips of the day
+messages:
+  ticker_interval: 1
+remote_config:
+  update_interval: 10
+  remote:
+    owner: annertech
+    repo: remote-config
+    ref: annertech-tips
+    filepath: remote-config.jsonc
+# End of Annertech tips of the day
+EOL

--- a/commands/host/annertech-tip-of-the-day
+++ b/commands/host/annertech-tip-of-the-day
@@ -4,16 +4,34 @@
 ## Usage: install-tips
 ## Example: "ddev install-tips"
 
+uninstall=false
 GLOBAL_CONF=~/.ddev/global_config.yaml
 
-if grep -q 'CUSTOM_TIPS_START' $GLOBAL_CONF; then
-  echo "Custom tips already installed, aborting."
-else
-  echo "Removing old tips"
-  rm ~/.ddev/.state.yaml ~/.ddev/.remote-config
-  echo "Installing tips of the day"
-cat <<EOL >> $GLOBAL_CONF
+for arg in "$@"; do
+  if [[ "$arg" == "-u" || "$arg" == "--uninstall" ]]; then
+    uninstall=true
+  fi
+done
 
+if [[ $uninstall == true ]]; then
+  echo "Uninstalling Annertech tips of the day"
+  if grep -q 'ANNERTECH_CUSTOM_TIPS_START' $GLOBAL_CONF; then
+    sed -i '/^##ANNERTECH_CUSTOM_TIPS_START/,/^##ANNERTECH_CUSTOM_TIPS_END/d' $GLOBAL_CONF
+    rm ~/.ddev/.state.yaml ~/.ddev/.remote-config
+    echo "Uninstalled Annertech tips of the day"
+  else
+    echo "No Annertech tips found, nothing to uninstall. Aborting..."
+  fi
+fi
+
+if [[ $uninstall == false ]]; then
+  if grep -q 'ANNERTECH_CUSTOM_TIPS_START' $GLOBAL_CONF; then
+    echo "Annertech tips already installed. Aborting..."
+  else
+    echo "Removing default DDEV tips"
+    rm ~/.ddev/.state.yaml ~/.ddev/.remote-config
+    echo "Installing Annertech tips of the day"
+cat <<EOL >> $GLOBAL_CONF
 ##ANNERTECH_CUSTOM_TIPS_START
 # Annertech tips of the day
 messages:
@@ -28,4 +46,6 @@ remote_config:
 # End of Annertech tips of the day
 ##ANNERTECH_CUSTOM_TIPS_END
 EOL
+  fi
 fi
+  

--- a/install.yaml
+++ b/install.yaml
@@ -91,6 +91,7 @@ project_files:
   - settings.local.devmode.php
   - settings.local.perfmode.php
   - scripts
+  - commands/host/annertech-tip-of-the-day
   - commands/host/branch
   - commands/host/cex
   - commands/host/cim
@@ -120,6 +121,7 @@ project_files:
 # even if a project doesn't have the addon installed yet.
 # Project level commands take priority.
 global_files:
+  - commands/host/annertech-tip-of-the-day
   - commands/host/open-issue
   - commands/host/timew
   - commands/host/branch
@@ -182,6 +184,7 @@ removal_actions:
   - rm config.annertech.yaml
   - rm settings.local.perfmode.php
   - rm settings.local.devmode.php
+  - rm commands/host/annertech-tip-of-the-day
   - rm commands/host/branch
   - rm commands/host/protect
   - rm commands/host/branch

--- a/install.yaml
+++ b/install.yaml
@@ -185,6 +185,15 @@ removal_actions:
   - rm settings.local.perfmode.php
   - rm settings.local.devmode.php
   - rm commands/host/annertech-tip-of-the-day
+  - |
+    #ddev-nodisplay
+    #ddev-description:Removing custom annertech tip of the day
+    if [ -f ~/.ddev/global_config.yaml ]; then
+      if grep -q 'ANNERTECH_CUSTOM_TIPS_START' ~/.ddev/global_config.yaml; then
+        sed -i '/^##ANNERTECH_CUSTOM_TIPS_START/,/^##ANNERTECH_CUSTOM_TIPS_END/d' ~/.ddev/global_config.yaml
+        rm ~/.ddev/.state.yaml ~/.ddev/.remote-config
+      fi
+    fi
   - rm commands/host/branch
   - rm commands/host/protect
   - rm commands/host/branch


### PR DESCRIPTION
## What
This can be used to display tips about custom command set etc.

## Why
Following the results of a small and rough questionaire, it became kind of clear that people use DDEV but don't spend time to read the command-set provided to them (nor the README on how to install the add-on).

Some examples:
- ![image](https://github.com/user-attachments/assets/b8484ab5-7c95-4659-9e44-97a88659bc18)
- ![image](https://github.com/user-attachments/assets/2844bece-15f3-4c51-8f5e-299ec25b1880)

Communicating features, changes, anything to a team of 30+ developers, in remote locations and timezones has proven difficult if not impossible.

_Spamming_ them with tips might be improve things:
![image](https://github.com/user-attachments/assets/113d5eb9-3b71-440f-bbd8-28c02cf21c3f)

## How
Upon merging this, users would have to run `ddev install-tips` or run a custom script which we'll provide in chat to get the new config set.

## Where
The messages are hosted here: https://github.com/Annertech/remote-config/