### PR TITLE
Review GitHub issue #90 for DDEV project

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -135,7 +135,7 @@ post_install_actions:
   - |
     if [ -f .env ]; then
       source ".env"
-      if [[ $DDEV_UPSTREAM_PROVIDER ]]; then
+      if [[ ${DDEV_UPSTREAM_PROVIDER:-} ]]; then
         ddev dotenv set .ddev/.env.anner --ddev-upstream-provider $DDEV_UPSTREAM_PROVIDER
         git add .env.anner
         # Remove our old .env file


### PR DESCRIPTION
Fixes #90

The post-install script was failing when DDEV_UPSTREAM_PROVIDER was not defined in the .env file. The script uses 'set -u' flag (via pipefail) which treats unset variables as errors.

Changed the conditional check from '$DDEV_UPSTREAM_PROVIDER' to '${DDEV_UPSTREAM_PROVIDER:-}' to use parameter expansion that provides an empty string if the variable is unset, preventing the script from failing when the variable doesn't exist.

## Summary
- Fixes #90: post-install action fails on MacOS with "DDEV_UPSTREAM_PROVIDER: unbound variable" error
- Changed variable reference from `$DDEV_UPSTREAM_PROVIDER` to `${DDEV_UPSTREAM_PROVIDER:-}` to safely handle unset variables

## Problem
The post-install script in `install.yaml` was failing on MacOS when the `DDEV_UPSTREAM_PROVIDER` variable was not defined in the `.env` file. The script uses bash's `-u` flag (treat unset variables as errors), which caused the script to exit immediately when trying to reference the undefined variable, even though it was inside a conditional check.

## Solution
Used parameter expansion syntax `${DDEV_UPSTREAM_PROVIDER:-}` which provides an empty string if the variable is unset, allowing the conditional check to work properly without triggering an unbound variable error.

## Test Plan
- [x] Code change made in install.yaml:138
- [ ] Test installation on MacOS without DDEV_UPSTREAM_PROVIDER in .env file
- [ ] Test installation on MacOS with DDEV_UPSTREAM_PROVIDER in .env file
- [ ] Verify migration from old .env to .env.anner works when variable is set

