### PR TITLE
fix: Stop MR command if git push fails

### DIFF
--- a/commands/host/mr
+++ b/commands/host/mr
@@ -6,6 +6,8 @@
 ## Usage: mr
 ## Example: "ddev mr"
 
+set -e # Prevent MR creation if git push fails
+
 #DOMAIN="${TEAMWORK_DOMAIN}"
 #
 #if [[ -z "$DOMAIN" ]]; then


### PR DESCRIPTION
Prevents issue where sanity checks fail, consequently git push is aborted but script still tries to create MR.

Closes #111 