### PR TITLE
Helper command 3rd party addons

### DIFF
--- a/commands/common/check-addon
+++ b/commands/common/check-addon
@@ -2,6 +2,10 @@
 #ddev-generated
 #annertech-ddev
 
+## Description: Helper command to ensure a required DDEV add-on is installed for this project
+## Usage: check-addon <repository> [reason]
+## Example: ddev check-addon ddev/ddev-cypress "Cypress tests"
+
 set -euo pipefail
 
 bold=$(tput bold)
@@ -16,8 +20,7 @@ REPO="$1"
 REASON="${2:-}"
 ADDON_NAME="${REPO##*/}"
 
-ADDON_METADATA_BASE="${DDEV_APPROOT}/.ddev/addon-metadata"
-MANIFEST="${ADDON_METADATA_BASE}/${ADDON_NAME}/manifest.yaml"
+MANIFEST="${DDEV_APPROOT}/.ddev/addon-metadata/${ADDON_NAME}/manifest.yaml"
 
 # ---------------------------------------------------------------------------
 # Success path: already installed
@@ -32,25 +35,22 @@ fi
 # ---------------------------------------------------------------------------
 echo >&2
 echo "❌ Required DDEV add-on not installed: ${REPO}" >&2
-# echo "   Add-on : ${REPO}" >&2
 
 if [ -n "${REASON}" ]; then
-  echo ""
   echo "   ${bold}Add-on is needed to run ${REASON}${normal}" >&2
 fi
-
 echo >&2
 
 # ---------------------------------------------------------------------------
 # Non-interactive (CI, automation)
 # ---------------------------------------------------------------------------
 if [ "${DDEV_NONINTERACTIVE:-false}" = "true" ]; then
-  echo "⚙️  Non-interactive mode detected; installing automatically…" >&2
-  if ddev add-on get "${REPO}"; then
+  echo "⚙️  Non-interactive mode detected; installing ${REPO} automatically…" >&2
+  if ddev add-on get "${REPO}" >&2; then
     echo "installed"
     exit 0
   else
-    echo "❌ Failed to install ${REPO}" >&2
+    echo "❌ Failed to install add-on: ${REPO}" >&2
     exit 1
   fi
 fi
@@ -61,19 +61,16 @@ fi
 read -r -p "Install ${REPO} now? [Y/n] " reply
 
 if [[ "${reply}" =~ ^[Nn]$ ]]; then
-  echo >&2
   echo "⚠️  Skipping add-on installation at user request." >&2
   if [ -n "${REASON}" ]; then
     echo "   ${REASON} will not be available." >&2
   fi
-  echo "not-installed"
+  echo >&2
+  echo "skipped"
   exit 0
 fi
 
-if ddev add-on get "${REPO}"; then
-  echo "installed"
-  exit 0
-else
-  echo "❌ Failed to install ${REPO}" >&2
-  exit 1
-fi
+ddev add-on get "${REPO}" >&2
+echo >&2
+echo "installed"
+exit 0

--- a/commands/common/check-addon
+++ b/commands/common/check-addon
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#ddev-generated
+#annertech-ddev
+
+set -euo pipefail
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+if [ "$#" -lt 1 ]; then
+  echo "❌ Usage: ddev check-addon <repository> [reason]" >&2
+  exit 2
+fi
+
+REPO="$1"
+REASON="${2:-}"
+ADDON_NAME="${REPO##*/}"
+
+ADDON_METADATA_BASE="${DDEV_APPROOT}/.ddev/addon-metadata"
+MANIFEST="${ADDON_METADATA_BASE}/${ADDON_NAME}/manifest.yaml"
+
+# ---------------------------------------------------------------------------
+# Success path: already installed
+# ---------------------------------------------------------------------------
+if [ -f "${MANIFEST}" ]; then
+  echo "installed"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Missing add-on (human output)
+# ---------------------------------------------------------------------------
+echo >&2
+echo "❌ Required DDEV add-on not installed: ${REPO}" >&2
+# echo "   Add-on : ${REPO}" >&2
+
+if [ -n "${REASON}" ]; then
+  echo ""
+  echo "   ${bold}Add-on is needed to run ${REASON}${normal}" >&2
+fi
+
+echo >&2
+
+# ---------------------------------------------------------------------------
+# Non-interactive (CI, automation)
+# ---------------------------------------------------------------------------
+if [ "${DDEV_NONINTERACTIVE:-false}" = "true" ]; then
+  echo "⚙️  Non-interactive mode detected; installing automatically…" >&2
+  if ddev add-on get "${REPO}"; then
+    echo "installed"
+    exit 0
+  else
+    echo "❌ Failed to install ${REPO}" >&2
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Interactive
+# ---------------------------------------------------------------------------
+read -r -p "Install ${REPO} now? [Y/n] " reply
+
+if [[ "${reply}" =~ ^[Nn]$ ]]; then
+  echo >&2
+  echo "⚠️  Skipping add-on installation at user request." >&2
+  if [ -n "${REASON}" ]; then
+    echo "   ${REASON} will not be available." >&2
+  fi
+  echo "not-installed"
+  exit 0
+fi
+
+if ddev add-on get "${REPO}"; then
+  echo "installed"
+  exit 0
+else
+  echo "❌ Failed to install ${REPO}" >&2
+  exit 1
+fi

--- a/commands/host/tests
+++ b/commands/host/tests
@@ -4,58 +4,83 @@
 
 ## Description: Informs you about available test suites in current project
 ## Usage: tests
-## Example: "ddev tests"
+## Example: ddev tests
 
-underline=`tput smul`
-nounderline=`tput rmul`
-bold=`tput bold`
-normal=`tput sgr0`
+set -euo pipefail
 
+underline=$(tput smul)
+nounderline=$(tput rmul)
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+echo
+
+# ---------------------------------------------------------------------------
 # Backstop
+# ---------------------------------------------------------------------------
 if [ -f "${DDEV_APPROOT}/tests/backstop/backstop.json" ]; then
-  echo
-  echo "${bold}Backstop:${normal}"
-  echo "  ddev backstop reference"
-  echo "  ddev backstop test"
-  echo "  ddev backstop-results"
+  backstop_addon="$(
+    ddev check-addon \
+    ddev/ddev-backstopjs \
+    "Backstop tests"
+  )"
+
+  if [ "${backstop_addon}" = "installed" ]; then
+    echo "${bold}Backstop:${normal}"
+    echo "  ddev backstop reference"
+    echo "  ddev backstop test"
+    echo "  ddev backstop-results"
+    echo
+  fi
 fi
 
+# ---------------------------------------------------------------------------
 # Behat
+# ---------------------------------------------------------------------------
 if [ -f "${DDEV_APPROOT}/tests/behat/behat.yml" ]; then
-  echo
   echo "${bold}Behat:${normal}"
   echo "  ddev ssh"
   echo "  cd tests/behat"
   echo "  bin/behat"
+  echo
 fi
 
+# ---------------------------------------------------------------------------
 # Bruno
-# @todo: check for postman?
-# @todo: run them with DDEV?
+# ---------------------------------------------------------------------------
 if [ -f "${DDEV_APPROOT}/tests/bruno/bruno/bruno.json" ]; then
-  echo
   echo "${bold}Bruno:${normal}"
   echo "  Runs outside DDEV, see https://www.usebruno.com/"
+  echo
 fi
 
+# ---------------------------------------------------------------------------
 # Cypress
-if [ -f "cypress.config.js" ]; then
-  echo
-  echo "${bold}Cypress:${normal}"
-  echo "  ddev cypress-run"
-  echo "  ddev cypress-run --headed"
-  echo "  ddev cypress-open"
-  echo
-  echo "If getting X related errors run xhost **first!**"
-  # First, ensure xhost allows connections
-  echo "xhost +local:"
+# ---------------------------------------------------------------------------
+if [ -f "${DDEV_APPROOT}/cypress.config.js" ]; then
+  cypress_addon="$(
+    ddev check-addon \
+      ddev/ddev-cypress \
+      "Cypress tests"
+  )"
+
+  if [ "${cypress_addon}" = "installed" ]; then
+    echo "${bold}Cypress:${normal}"
+    echo "  ddev cypress-run"
+    echo "  ddev cypress-run --headed"
+    echo "  ddev cypress-open"
+    echo
+    echo "If getting X related errors run xhost ${bold}first${normal}!"
+    echo "  xhost +local:"
+    echo
+  fi
 fi
 
+# ---------------------------------------------------------------------------
 # PHPUnit
+# ---------------------------------------------------------------------------
 if [ -f "${DDEV_APPROOT}/vendor/bin/phpunit" ]; then
-  echo
   echo "${bold}PHPUnit:${normal}"
   echo "  ddev phpunit"
+  echo
 fi
-
-echo

--- a/commands/host/tests
+++ b/commands/host/tests
@@ -20,12 +20,10 @@ echo
 # ---------------------------------------------------------------------------
 if [ -f "${DDEV_APPROOT}/tests/backstop/backstop.json" ]; then
   backstop_addon="$(
-    ddev check-addon \
-    ddev/ddev-backstopjs \
-    "Backstop tests"
+    ddev check-addon ddev/ddev-backstopjs "Backstop tests"
   )"
 
-  if [ "${backstop_addon}" = "installed" ]; then
+  if [ "$backstop_addon" = "installed" ]; then
     echo "${bold}Backstop:${normal}"
     echo "  ddev backstop reference"
     echo "  ddev backstop test"
@@ -59,12 +57,10 @@ fi
 # ---------------------------------------------------------------------------
 if [ -f "${DDEV_APPROOT}/cypress.config.js" ]; then
   cypress_addon="$(
-    ddev check-addon \
-      ddev/ddev-cypress \
-      "Cypress tests"
+    ddev check-addon ddev/ddev-cypress "Cypress tests"
   )"
 
-  if [ "${cypress_addon}" = "installed" ]; then
+  if [ "$cypress_addon" = "installed" ]; then
     echo "${bold}Cypress:${normal}"
     echo "  ddev cypress-run"
     echo "  ddev cypress-run --headed"


### PR DESCRIPTION
Related to #101 

Creates a "simple" helper command for checking if an add-on is installed by looking if add-on manifest exists in `.ddev/addon-metadata`.
Intended to be leverage by other commands.

Updated `tests` command to leverage `check-addon` helper command for backstopJS and Cypress, both of which require ddev add-ons to run.

Prompts user to install add-on, if they decline it informs that tests will not be available, and does not show the relevant tests commands.