### PR TITLE
ci: add per-PR docs-sync workflow

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,52 @@
+name: docs-sync
+
+# On every PR, keep docs/ in sync with the code the PR touches.
+# Pairs with the weekly "Weekly docs sync from main" cloud routine which
+# catches commits landed directly on main.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: docs-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  docs-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            This PR (#${{ github.event.pull_request.number }}) changes the
+            Annertech DDEV add-on. Update the Markdown docs under docs/ to
+            reflect ONLY what this PR changes.
+
+            Scope of documentation:
+              - host commands (commands/host/)
+              - web container commands (commands/web/)
+              - git hooks (scripts/git-hooks/)
+              - custom DDEV providers
+              - lifecycle hooks in config.annertech.yaml
+              - settings.*.php (settings.local.devmode.php, settings.local.perfmode.php)
+
+            IGNORE everything related to Varnish (scripts/varnish/, VCL configs).
+            Do NOT document Varnish.
+
+            If docs/ does not exist, create it covering the scope above.
+            Read the actual changed files so the prose is accurate.
+            Commit any doc changes directly to this PR's branch with a
+            Co-Authored-By: Claude trailer. If docs already match the code,
+            make no changes.
+          claude_args: |
+            --allowedTools "Bash,Read,Write,Edit,Glob,Grep"


### PR DESCRIPTION
Runs Claude Code Action on every PR to keep docs/ in sync with the code the PR touches.