### PR TITLE
docs: weekly sync

### DIFF
--- a/docs/host-commands.md
+++ b/docs/host-commands.md
@@ -8,7 +8,7 @@ These commands run on the developer's host machine (via `ddev <command>`), from 
 
 ## Commands
 
-- `ai-prompts` — Interactive fzf menu ("AI Prompts Operations Centre") offering BackstopJS-init prompt generation (extracts test/reference domains, feeds a templated prompt to a chosen AI agent) and access-log forensics (GDPR-safe IP masking via `mask_ips.py` before sending log excerpts to an LLM). Aliases: `ai`.
+- `ai-prompts` — Interactive fzf menu ("AI Prompts Operations Centre") offering BackstopJS-init prompt generation (extracts test/reference domains, feeds a templated prompt to a chosen AI agent: Gemini, Copilot, Claude, Antigravity via `agy --prompt`, or Prompt which echoes the raw text for manual use) and access-log forensics (GDPR-safe IP masking via `mask_ips.py` before sending log excerpts to an LLM; supports Gemini, Copilot, and Claude). Aliases: `ai`.
 - `annertech-tip-of-the-day` — Installs (or removes with `-u`/`--uninstall`) a custom DDEV "tip of the day" remote-config entry in `~/.ddev/global_config.yaml` pointing at Annertech's tips repo, clearing DDEV state so the change takes effect. Note: header `## Usage` says `install-tips`, which is stale/inconsistent with the actual filename.
 - `backstop-public` — Copies the BackstopJS HTML report into the web root so it's reachable over HTTP, prints the URL, and deletes the copy automatically after 5 minutes.
 - `branch` — Creates a git branch named `YYYYMM_T-<taskid>__<description>` from a Teamwork card URL/ID and description. Blocks branching from forbidden base branches (dev/develop/development/stage/staging) and warns to pull first when branching from main/master. Aliases: `branch`, `br`.


### PR DESCRIPTION
## What changed and why

One direct commit landed on `main` this week that touches a documented area:

**`36f57bd` (2026-07-09) — "More options for backstop ai init"**  
File: `commands/host/ai-prompts`

Added two new AI agent choices to the **BackstopJS init** flow only:
- **Antigravity** — calls `agy --prompt "<prompt>"`
- **Prompt** — echoes the raw prompt text to stdout for manual copy-paste

The access-log forensics flow is unchanged and continues to support only Gemini, Copilot, and Claude.

## Docs update

Updated `docs/host-commands.md` entry for `ai-prompts` to enumerate all five agents available in the BackstopJS init flow and note that access-log forensics uses only the three-agent subset (Gemini, Copilot, Claude).

No other files changed; no other direct-to-main commits this week touched documented areas.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7HLo6YNCEQpkfMujWwAwc)_