### PR TITLE
exclude tests from pre-commit checks

### DIFF
--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -55,7 +55,7 @@ if [ -f ".ddev/.env.anner" ]; then
     fi
 fi
 
-STAGED_FILES=$(git diff --cached --name-only | grep -E "$FILES_PATTERN")
+STAGED_FILES=$(git diff --cached --name-only | grep -vE "(^|/)tests(/|$)" | grep -E "$FILES_PATTERN")
 if [ -n "$STAGED_FILES" ]; then
     for FORBIDDEN_PATTERN in "${FORBIDDEN_PATTERNS[@]}"; do
         echo "$STAGED_FILES" | xargs grep --color --with-filename -n "$FORBIDDEN_PATTERN" \


### PR DESCRIPTION
exclude tests from pre-commit checks 
issue is e.g web/core/tests/fixtures/config_install/multilingual/core.extension.yml which has page_cache: 0 
halts commits 
I'v excluded "tests" but we could more precise and only exclude "core/tests" but sticking with that pattern for now 