### PR TITLE
docs: weekly sync

### DIFF
--- a/docs/drupal-settings.md
+++ b/docs/drupal-settings.md
@@ -12,7 +12,7 @@ Both files share most of their baseline overrides:
 - Overrides the Search API Solr connector to use the local `solr` service (`http://solr:8983/`, core `dev`).
 - Overrides SMTP settings to point at `localhost:1025` (a local mail-capture tool such as Mailhog), with blank credentials.
 - Defaults `file_private_path` to `../private` if not already set.
-- Disables Shield, TFA, IP restriction (`restrict_ip`), and clears the Fastly API key/site ID — security/CDN modules that shouldn't be active locally.
+- Disables Shield, TFA, IP restriction (`restrict_ip`), OpenTelemetry (`opentelemetry.settings.disable`), and clears the Fastly API key/site ID — security/CDN/observability modules that shouldn't be active locally.
 - Sets `rebuild_access = TRUE` and `skip_permissions_hardening = TRUE`.
 - Excludes `devel`, `devel_a11y`, `devel_php`, `stage_file_proxy`, `twig_vardumper`, `upgrade_status`, and `drush_endpoint` from configuration sync (`config_exclude_modules`), so these dev-only modules never leak into exported config.
 - Includes an optional `settings.project.php` (in the same directory) if present, for project-specific overrides.

--- a/docs/git-hooks.md
+++ b/docs/git-hooks.md
@@ -19,7 +19,7 @@ A multi-check guard over staged files. Any failing check blocks the commit (exit
 1. Rejects staged `system.performance.yml` containing `preprocess: false` (CSS/JS aggregation disabled).
 2. Rejects staged `system.performance.yml` (excluding paths under `tests/`) containing `max_age: 0` (browser caching disabled).
 3. Rejects staged `system.performance.yml` (excluding `tests/`) containing `gzip: true` (AdvAgg GZIP enabled).
-4. Rejects staged `core.extension.yml` enabling forbidden modules: `devel: 0`, `devel_php: 0`, `drush_endpoint: 0` (Drupal's YAML convention where `: 0` means "enabled"). If `.ddev/.env.anner` exists and `DDEV_UPSTREAM_PROVIDER` is `platform` or `upsun`, it additionally forbids enabling ` page_cache: 0` (the leading space is intentional, to avoid matching `dynamic_page_cache`).
+4. Rejects staged `core.extension.yml` (excluding paths under `tests/`) enabling forbidden modules: `devel: 0`, `devel_php: 0`, `drush_endpoint: 0` (Drupal's YAML convention where `: 0` means "enabled"). If `.ddev/.env.anner` exists and `DDEV_UPSTREAM_PROVIDER` is `platform` or `upsun`, it additionally forbids enabling ` page_cache: 0` (the leading space is intentional, to avoid matching `dynamic_page_cache`).
 5. Checks for a CDN module (Fastly or Cloudflare) enabled in `config/sync/core.extension.yml` while `.platform/routes.yaml` exists; if a CDN is enabled but the routes file doesn't disable Upsun's route cache (`enabled: false` under cache), it blocks with a warning that route cache must be disabled behind a CDN.
 6. Rejects commits with staged files under a `devel_php/` folder.
 7. If `.ddev/addon-metadata/annertech-ddev/manifest.yaml` is staged with no/empty `version:` field, blocks — this implies a dev/unpublished version of the addon is in use.


### PR DESCRIPTION
## What changed and why

Four commits landed directly on `main` between 2026-07-14 and 2026-07-23. Two of them touched documented areas:

### 1. `9a3e73d` — exclude tests from pre-commit checks (`scripts/git-hooks/pre-commit`)

Check 4 (the `core.extension.yml` forbidden-modules guard) now filters out files under `tests/` directories before running, consistent with checks 2 and 3 which already excluded test paths. **`docs/git-hooks.md`** updated to reflect this.

### 2. `d9bb965` — Disable opentelemetry locally (`settings.local.devmode.php`, `settings.local.perfmode.php`)

Both settings files gained `$config['opentelemetry.settings']['disable'] = true;`. **`docs/drupal-settings.md`** updated to include OpenTelemetry in the list of services disabled in both modes.

### Not documented

- `88e8d58` / `b103605` — changes to `commands/host/tests` (a BATS test helper, not a documented command).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MN3NH8HaLVoCpyAmXLD98P)_